### PR TITLE
Handle docs without paths

### DIFF
--- a/editor/editor_api.py
+++ b/editor/editor_api.py
@@ -8,6 +8,7 @@ from werkzeug import wrappers
 from grow.common import json_encoder
 from grow.common import utils
 from grow.common import yaml_utils
+from grow.documents import document
 from grow.documents import document_front_matter
 from grow.routing import router as grow_router
 
@@ -105,9 +106,16 @@ class PodApi(object):
             }
 
         serving_paths = {}
-        serving_paths[str(doc.default_locale)] = doc.get_serving_path()
-        for key, value in doc.get_serving_paths_localized().items():
-            serving_paths[str(key)] = value
+        try:
+            serving_path = doc.get_serving_path()
+            serving_paths[str(doc.default_locale)] = serving_path
+            for key, value in doc.get_serving_paths_localized().items():
+                serving_paths[str(key)] = value
+        except document.PathFormatError:
+            # Document is just a partial content file, or has no serving path,
+            # or has an error with its serving path.
+            serving_path = None
+            serving_paths = {}
 
         raw_front_matter = doc.format.front_matter.export()
         front_matter = yaml.load(

--- a/editor/source/editor/editor.js
+++ b/editor/source/editor/editor.js
@@ -63,7 +63,7 @@ export default class Editor {
         </div>
       </div>
       ${editor.isFullScreen ? '' : html`<div class="editor__preview">
-        <iframe src="${editor.servingPath}" @load=${editor.handlePreviewIframeNavigation.bind(editor)}></iframe>
+        <iframe ?hidden=${!editor.servingPath} src="${editor.servingPath}" @load=${editor.handlePreviewIframeNavigation.bind(editor)}></iframe>
       </div>`}
     </div>`
 


### PR DESCRIPTION
FYI to @Zoramite – this handles docs without paths and makes every content bit editable. The code change was small so I'm going to merge it in, but feel free to make post-submit changes to it to harden it for any reason. I also noticed there's a FOUC for the iframe, so we'll have to fix it.